### PR TITLE
Sara/test tasksize benchmark

### DIFF
--- a/Docs/CLI_Settings.txt
+++ b/Docs/CLI_Settings.txt
@@ -1,0 +1,59 @@
+---Encrypt Non-Parallel---
+python aestest.py -e -g 16 -i 100 -k AES.key -outf eval_files/nonParallel/encrypt/16b.enc
+python aestest.py -e -g 1024 -i 10 -k AES.key -outf eval_files/nonParallel/encrypt/1KB.enc
+python aestest.py -e -g 10240 -i 10 -k AES.key -outf eval_files/nonParallel/encrypt/10KB.enc
+python aestest.py -e -g 51200 -i 10 -k AES.key -outf eval_files/nonParallel/encrypt/50KB.enc
+python aestest.py -e -g 102400 -i 10 -k AES.key -outf eval_files/nonParallel/encrypt/100KB.enc
+python aestest.py -e -g 262144 -i 10 -k AES.key -outf eval_files/nonParallel/encrypt/256KB.enc
+python aestest.py -e -g 524288 -i 10 -k AES.key -outf eval_files/nonParallel/encrypt/512KB.enc
+python aestest.py -e -g 1048576 -i 10 -k AES.key -outf eval_files/nonParallel/encrypt/1MB.enc
+python aestest.py -e -g 10485760 -i 10 -k AES.key -outf eval_files/nonParallel/encrypt/10MB.enc
+python aestest.py -e -g 52428800 -i 10 -k AES.key -outf eval_files/nonParallel/encrypt/50MB.enc
+python aestest.py -e -g 104857600 -i 10 -k AES.key -outf eval_files/nonParallel/encrypt/100MB.enc
+python aestest.py -e -g 268435456 -i 10 -k AES.key -outf eval_files/nonParallel/encrypt/256MB.enc
+python aestest.py -e -g 536870912 -i 10 -k AES.key -outf eval_files/nonParallel/encrypt/512MB.enc
+
+---Decrypt Non-Parallel---
+python aestest.py -d -i 100 -k AES.key -inf eval_files/nonParallel/encrypt/16b.enc -outf eval_files/nonParallel/decrypt/16b_pt.txt
+python aestest.py -d -i 10 -k AES.key -inf eval_files/nonParallel/encrypt/1KB.enc -outf eval_files/nonParallel/decrypt/1KB_pt.txt
+python aestest.py -d -i 10 -k AES.key -inf eval_files/nonParallel/encrypt/10KB.enc -outf eval_files/nonParallel/decrypt/10KB_pt.txt
+python aestest.py -d -i 10 -k AES.key -inf eval_files/nonParallel/encrypt/50KB.enc -outf eval_files/nonParallel/decrypt/50KB_pt.txt
+python aestest.py -d -i 10 -k AES.key -inf eval_files/nonParallel/encrypt/100KB.enc -outf eval_files/nonParallel/decrypt/100KB_pt.txt
+python aestest.py -d -i 10 -k AES.key -inf eval_files/nonParallel/encrypt/256KB.enc -outf eval_files/nonParallel/decrypt/256KB_pt.txt
+python aestest.py -d -i 10 -k AES.key -inf eval_files/nonParallel/encrypt/512KB.enc -outf eval_files/nonParallel/decrypt/512KB_pt.txt
+python aestest.py -d -i 10 -k AES.key -inf eval_files/nonParallel/encrypt/1MB.enc -outf eval_files/nonParallel/decrypt/1MB_pt.txt
+python aestest.py -d -i 10 -k AES.key -inf eval_files/nonParallel/encrypt/10MB.enc -outf eval_files/nonParallel/decrypt/10MB_pt.txt
+python aestest.py -d -i 10 -k AES.key -inf eval_files/nonParallel/encrypt/50MB.enc -outf eval_files/nonParallel/decrypt/50MB_pt.txt
+python aestest.py -d -i 10 -k AES.key -inf eval_files/nonParallel/encrypt/100MB.enc -outf eval_files/nonParallel/decrypt/100MB_pt.txt
+python aestest.py -d -i 10 -k AES.key -inf eval_files/nonParallel/encrypt/256MB.enc -outf eval_files/nonParallel/decrypt/256MB_pt.txt
+python aestest.py -d -i 10 -k AES.key -inf eval_files/nonParallel/encrypt/512MB.enc -outf eval_files/nonParallel/decrypt/512MB_pt.txt
+
+---Encrypt Parallel---
+python aestest.py -e -p -w <n> -g 1024 -i 10 -k AES.key -outf eval_files/parallel/encrypt/1KB.enc
+python aestest.py -e -p -w <n> -g 10240 -i 10 -k AES.key -outf eval_files/parallel/encrypt/10KB.enc
+python aestest.py -e -p -w <n> -g 51200 -i 10 -k AES.key -outf eval_files/parallel/encrypt/50KB.enc
+python aestest.py -e -p -w <n> -g 102400 -i 10 -k AES.key -outf eval_files/parallel/encrypt/100KB.enc
+python aestest.py -e -p -w <n> -g 262144 -i 10 -k AES.key -outf eval_files/parallel/encrypt/256KB.enc
+python aestest.py -e -p -w <n> -g 524288 -i 10 -k AES.key -outf eval_files/parallel/encrypt/512KB.enc
+python aestest.py -e -p -w <n> -g 1048576 -i 10 -k AES.key -outf eval_files/parallel/encrypt/1MB.enc
+python aestest.py -e -p -w <n> -g 10485760 -i 10 -k AES.key -outf eval_files/parallel/encrypt/10MB.enc
+python aestest.py -e -p -w <n> -g 52428800 -i 10 -k AES.key -outf eval_files/parallel/encrypt/50MB.enc
+python aestest.py -e -p -w <n> -g 104857600 -i 10 -k AES.key -outf eval_files/parallel/encrypt/100MB.enc
+python aestest.py -e -p -w <n> -g 268435456 -i 10 -k AES.key -outf eval_files/parallel/encrypt/256MB.enc
+python aestest.py -e -p -w <n> -g 536870912 -i 10 -k AES.key -outf eval_files/parallel/encrypt/512MB.enc
+python aestest.py -e -p -w <n> -g 1073741824 -i 10 -k AES.key -outf eval_files/parallel/encrypt/1GB.enc
+
+---Decrypt Parallel---
+python aestest.py -e -p -w <n> -i 10 -k AES.key -inf eval_files/parallel/encrypt/1KB.enc -outf eval_files/parallel/decrypt/1KB_pt.txt
+python aestest.py -e -p -w <n> -i 10 -k AES.key -inf eval_files/parallel/encrypt/10KB.enc -outf eval_files/parallel/decrypt/10KB_pt.txt
+python aestest.py -e -p -w <n> -i 10 -k AES.key -inf eval_files/parallel/encrypt/50KB.enc -outf eval_files/parallel/decrypt/50KB_pt.txt
+python aestest.py -e -p -w <n> -i 10 -k AES.key -inf eval_files/parallel/encrypt/100KB.enc -outf eval_files/parallel/decrypt/100KB_pt.txt
+python aestest.py -e -p -w <n> -i 10 -k AES.key -inf eval_files/parallel/encrypt/256KB.enc -outf eval_files/parallel/decrypt/256KB_pt.txt
+python aestest.py -e -p -w <n> -i 10 -k AES.key -inf eval_files/parallel/encrypt/512KB.enc -outf eval_files/parallel/decrypt/512KB_pt.txt
+python aestest.py -e -p -w <n> -i 10 -k AES.key -inf eval_files/parallel/encrypt/1MB.enc -outf eval_files/parallel/decrypt/1MB_pt.txt
+python aestest.py -e -p -w <n> -i 10 -k AES.key -inf eval_files/parallel/encrypt/10MB.enc -outf eval_files/parallel/decrypt/10MB_pt.txt
+python aestest.py -e -p -w <n> -i 10 -k AES.key -inf eval_files/parallel/encrypt/50MB.enc -outf eval_files/parallel/decrypt/50MB_pt.txt
+python aestest.py -e -p -w <n> -i 10 -k AES.key -inf eval_files/parallel/encrypt/100MB.enc -outf eval_files/parallel/decrypt/100MB_pt.txt
+python aestest.py -e -p -w <n> -i 10 -k AES.key -inf eval_files/parallel/encrypt/256MB.enc -outf eval_files/parallel/decrypt/256MB_pt.txt
+python aestest.py -e -p -w <n> -i 10 -k AES.key -inf eval_files/parallel/encrypt/512MB.enc -outf eval_files/parallel/decrypt/512MB_pt.txt
+python aestest.py -e -p -w <n> -i 10 -k AES.key -inf eval_files/parallel/encrypt/1GB.enc -outf eval_files/parallel/decrypt/1GB_pt.txt

--- a/aesdecrypt.py
+++ b/aesdecrypt.py
@@ -656,6 +656,7 @@ def AES_Decrypt(args, key):
     """
     print("[INFO]: Non-Parallelized Decryption")
     plaintext = b''
+    decrypted_blocks = []
     with open(args.inf, 'rb') as infile:
         data = infile.read()
 
@@ -664,13 +665,15 @@ def AES_Decrypt(args, key):
         start = time.time_ns()
         for x in range(num_blocks):
             block = data[x*16: (x*16)+16]
-            plaintext += (aes_decrypt(block, key))
+            decrypted_blocks.append(aes_decrypt(block, key))
             #print(f'[INFO]: Blocks remaining: {num_blocks - x}')
         end = time.time_ns()
 
         total_time = (end - start) / 1e9
         print(f'[INFO]: Non-Parallelized AES Decryption took {total_time} s')
-
+        
+        plaintext = b''.join(decrypted_blocks)
+        
         unpadded = tools.iso_iec_7816_4_unpad(plaintext)
 
     with open(args.outf, 'wb') as outfile:

--- a/aesdecrypt.py
+++ b/aesdecrypt.py
@@ -591,13 +591,14 @@ def aes_dec_parallel( padded, key):
     Description: Perform Parallelized AES Decryption
     """
     global MAX_WORKERS
-    print("[INFO]: Parallelized Decryption")
+    #print("[INFO]: Parallelized Decryption")
     plaintext = b''
     decrypted_blocks = []
     futures = []
     
     parts = []
-    print(f'[INFO]: Max workers: {MAX_WORKERS}\r')
+    #
+    # print(f'[INFO]: Max workers: {MAX_WORKERS}\r')
     # Loop to create parts
     part_size = len(padded) // MAX_WORKERS
 
@@ -630,7 +631,7 @@ def aes_dec_parallel( padded, key):
 
     plaintext = tools.iso_iec_7816_4_unpad(plaintext)
 
-    print(f'[INFO]: Parallelized AES decryption took {(end - start) / 1e9} s')
+    #print(f'[INFO]: Parallelized AES decryption took {(end - start) / 1e9} s')
     
 def aes_dec_main(ct, key):
     """
@@ -654,7 +655,7 @@ def AES_Decrypt(args, key):
     Output :     None
     Description: Perform Non-Parallelized AES Decryption
     """
-    print("[INFO]: Non-Parallelized Decryption")
+    #print("[INFO]: Non-Parallelized Decryption")
     plaintext = b''
     decrypted_blocks = []
     with open(args.inf, 'rb') as infile:
@@ -690,7 +691,7 @@ def AES_Decrypt_Parallelized(args, key):
     Description: Perform Parallelized AES Decryption
     """
     global MAX_WORKERS
-    print("[INFO]: Parallelized Decryption")
+    #print("[INFO]: Parallelized Decryption")
     plaintext = b''
     decrypted_blocks = []
     futures = []
@@ -711,7 +712,7 @@ def AES_Decrypt_Parallelized(args, key):
         else:
             workers = MAX_WORKERS
 
-        print(f'[INFO]: Max workers: {workers}\r')
+        #print(f'[INFO]: Max workers: {workers}\r')
 
         # Loop to create parts
         part_size = len(padded) // workers
@@ -748,7 +749,7 @@ def AES_Decrypt_Parallelized(args, key):
 
         plaintext = tools.iso_iec_7816_4_unpad(plaintext)
 
-        print(f'[INFO]: Parallelized AES decryption took {total_time} s')
+        #print(f'[INFO]: Parallelized AES decryption took {total_time} s')
         with open(args.outf, 'wb') as outfile:
             outfile.write(plaintext)
 

--- a/aesencrypt.py
+++ b/aesencrypt.py
@@ -628,6 +628,7 @@ def AES_Encrypt(args, key):
     """
     print("[INFO]: Non-Parallelized Encryption")
     ciphertext = b''
+    encrypted_blocks = []
     with open(args.inf, 'rb') as infile:
         data = infile.read()
 
@@ -641,12 +642,15 @@ def AES_Encrypt(args, key):
         start = time.time_ns()
         for x in range(num_blocks):
             block = padded[x*16: (x*16)+16]
-            ciphertext += (aes_encrypt(block, key))
+            encrypted_blocks.append(aes_encrypt(block, key))
             #print(f'[INFO]: Blocks remaining: {num_blocks - x}')
         end = time.time_ns()
         total_time = (end - start) / 1e9
         print(f'[INFO]: Non-Parallelized AES Encryption took {total_time} s')
 
+    # combine into single bytestream
+    ciphertext = b''.join(encrypted_blocks)
+    
     with open(args.outf, 'wb') as outfile:
         outfile.write(ciphertext)
 

--- a/aesencrypt.py
+++ b/aesencrypt.py
@@ -786,11 +786,7 @@ def AES_Enc_Parallel_chunksize(args, key):
         start = time.time_ns()
         # map(): Apply a function to an iterable of elements.
         with ProcessPoolExecutor(max_workers=workers) as executor:
-            #futures.extend(executor.submit(aes_encrypt, blocks, key, chunksize=chunkSize))
-            #futures.extend(executor.map(aes_encrypt, block, key, chunksize=chunkSize) for block in blocks)
-            #for result in (executor.map(aes_encrypt, block, key, chunksize=chunkSize) for block in blocks):
-                #print(f'Result: {result}')
-                #futures.extend(result)
+           
             for result in executor.map(encryptor, arguments ):
                 #print(result)
                 encrypted_blocks.append(result)

--- a/aesencrypt.py
+++ b/aesencrypt.py
@@ -421,6 +421,8 @@ def extract_key(key):
     """
     byte_arr = [[0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]]
 
+    #print(f'Key in extract_key: {key}')
+
     for i in range(4):
         converter = key[i].to_bytes(4, byteorder='big', signed=False)
         byte_arr[0][i] = int(converter[0])
@@ -508,7 +510,7 @@ def aes_encrypt(pt, key):
 
     return ciphertext
 
-def aes_enc_parallel( padded, key):
+def aes_enc_parallel( padded, key, chunksize):
     """
     Function :   AES_Encrypt_Parallelized
     Parameters : padded plaintext string, bytestring key
@@ -626,7 +628,7 @@ def AES_Encrypt(args, key):
     Output :     None
     Description: Perform Non-Parallelized AES Encryption
     """
-    print("[INFO]: Non-Parallelized Encryption")
+    #print("[INFO]: Non-Parallelized Encryption")
     ciphertext = b''
     encrypted_blocks = []
     with open(args.inf, 'rb') as infile:
@@ -646,12 +648,12 @@ def AES_Encrypt(args, key):
             #print(f'[INFO]: Blocks remaining: {num_blocks - x}')
         end = time.time_ns()
         total_time = (end - start) / 1e9
-        print(f'[INFO]: Non-Parallelized AES Encryption took {total_time} s')
+        #print(f'[INFO]: Non-Parallelized AES Encryption took {total_time} s')
 
     # combine into single bytestream
     ciphertext = b''.join(encrypted_blocks)
     
-    with open(args.outf, 'wb') as outfile:
+    with open(args.outf, 'wb+') as outfile:
         outfile.write(ciphertext)
 
     return total_time
@@ -664,7 +666,7 @@ def AES_Encrypt_Parallelized(args, key):
     Output :     None
     Description: Perform Parallelized AES Encryption
     """
-    print("[INFO]: Parallelized Encryption")
+    #print("[INFO]: Parallelized Encryption")
     ciphertext = b''
     encrypted_blocks = []
     futures = []
@@ -686,7 +688,7 @@ def AES_Encrypt_Parallelized(args, key):
         else:
             workers = MAX_WORKERS
 
-        print(f'[INFO]: Max workers: {workers}\r')
+        #print(f'[INFO]: Max workers: {workers}\r')
 
         # Loop to create parts
         part_size = len(padded) // workers
@@ -721,8 +723,90 @@ def AES_Encrypt_Parallelized(args, key):
         end = time.time_ns()
 
         total_time = (end - start) / 1e9
-        print(f'[INFO]: Parallelized AES Encryption took {total_time} s')
-        with open(args.outf, 'wb') as outfile:
+        #print(f'[INFO]: Parallelized AES Encryption took {total_time} s')
+        with open(args.outf, 'wb+') as outfile:
             outfile.write(ciphertext)
 
+        return total_time
+    
+def encryptor(arguments):
+    return aes_encrypt(*arguments)
+
+def AES_Enc_Parallel_chunksize(args, key):
+    """
+    Function :   AES_Encrypt_Parallelized
+    Parameters : program arguments, key schedule array
+    Output :     None
+    Description: Perform Parallelized AES Encryption
+    """
+    #print("[INFO]: Parallelized Encryption")
+    ciphertext = b''
+    encrypted_blocks = []
+    futures = []
+    parts = []
+
+    print(f'Key in main func is: {key}')
+
+
+    global MAX_WORKERS
+    with open(args.inf, 'rb') as infile:
+        data = infile.read()
+
+        if len(data) % 16 != 0:
+            padded = tools.iso_iec_7816_4_pad(data)
+            num_blocks = int(len(padded)/16)
+        else:
+            num_blocks = int(len(data)/16)
+            padded = data
+
+        # Check if user has override MAX_WORKERS
+        if args.w != -1:
+            workers = args.w
+        else:
+            workers = MAX_WORKERS
+
+        #print(f'[INFO]: Max workers: {workers}\r')
+        chunkSize = args.c
+
+        # TODO: make a list of blocks, 16 bytes each
+        blocks = []
+
+        # Loop to create blocks
+        for x in range(num_blocks):
+            block = padded[x*16: (x*16)+16]
+            blocks.append(block)
+
+        print(f'Padded output:')
+        #print(blocks)
+
+
+        print(f'Chunksize: is {chunkSize} blocks per process')
+        arguments = [(block, key) for block in blocks]
+
+        start = time.time_ns()
+        # map(): Apply a function to an iterable of elements.
+        with ProcessPoolExecutor(max_workers=workers) as executor:
+            #futures.extend(executor.submit(aes_encrypt, blocks, key, chunksize=chunkSize))
+            #futures.extend(executor.map(aes_encrypt, block, key, chunksize=chunkSize) for block in blocks)
+            #for result in (executor.map(aes_encrypt, block, key, chunksize=chunkSize) for block in blocks):
+                #print(f'Result: {result}')
+                #futures.extend(result)
+            for result in executor.map(encryptor, arguments ):
+                #print(result)
+                encrypted_blocks.append(result)
+                
+            #for future in futures: # try as_completed(result)
+                #encrypted_blocks.append(future)
+                #print(list(future))
+
+        # Concatenate the encrypted blocks in the original order
+        ciphertext = b''.join(encrypted_blocks)
+        end = time.time_ns()
+
+        total_time = (end - start) / 1e9
+        #print(f'[INFO]: Parallelized AES Encryption took {total_time} s')
+        with open(args.outf, 'wb+') as outfile:
+            outfile.write(ciphertext)
+
+        #print(f'Ciphertext: {ciphertext}')
         return total_time

--- a/aestest.py
+++ b/aestest.py
@@ -140,15 +140,23 @@ if __name__ == '__main__':
 	key = tools.key_expansion(pre_key)
 
 	for _ in range(args.i):
-		if args.p:
-			if args.c != -1:
-				print("-------running chunksize test--------")
-				time = aesencrypt.AES_Enc_Parallel_chunksize(args, key)
-			elif args.encrypt:
-				time = aesencrypt.AES_Encrypt_Parallelized(args, key)
+
+		if args.p:   # PARALLEL RUNS
+			
+			if args.encrypt:   
+				if args.c != -1:
+					print("-------running Encrypt chunksize test--------")
+					time = aesencrypt.AES_Enc_Parallel_chunksize(args, key)
+				else:
+					time = aesencrypt.AES_Encrypt_Parallelized(args, key)    # Standard parallel encrypt
 			else:
-				time = aesdecrypt.AES_Decrypt_Parallelized(args, key)
-		else:
+				if args.c != -1:
+					print("-------Running Decrypt chunksize test--------")
+					time = aesdecrypt.AES_Dec_Parallel_chunksize(args, key)
+				else:
+					time = aesdecrypt.AES_Decrypt_Parallelized(args, key)
+
+		else:      # SEQUENTIAL RUNS
 			if args.encrypt:
 				time = aesencrypt.AES_Encrypt(args, key)
 			else:

--- a/aestest.py
+++ b/aestest.py
@@ -139,11 +139,9 @@ if __name__ == '__main__':
 	tools.print_key_hex(pre_key)
 	key = tools.key_expansion(pre_key)
 
-	# TODO : All AES Encrypt/Decrypt should return back times
-	# TODO : Merge @sara's evaluation code to wrap time calculation
 	for _ in range(args.i):
 		if args.p:
-			if args.c:
+			if args.c != -1:
 				print("-------running chunksize test--------")
 				time = aesencrypt.AES_Enc_Parallel_chunksize(args, key)
 			elif args.encrypt:
@@ -173,12 +171,3 @@ if __name__ == '__main__':
 	logger.info(f'Variance: {statistics.variance(TIME_TRIALS)}')  # NOTE: REQUIRES > 1 ITERATIONS
 	logger.info(f'Coefficient of Variation: {Coefficient_of_Variation}')
 	logger.info("------------------------------------")
-
-	print("           AES Statistics           ")
-	print("------------------------------------")
-	print(f'Number of Trials: {len(TIME_TRIALS)}')
-	print(f'Time Splits: {TIME_TRIALS}')
-	print(f'Average Time: {sum(TIME_TRIALS) / len(TIME_TRIALS)}')
-	print(f'Variance: {statistics.variance(TIME_TRIALS)}')  # NOTE: REQUIRES > 1 ITERATIONS
-	print(f'Coefficient of Variation: {Coefficient_of_Variation}')
-	print("------------------------------------")

--- a/aestest.py
+++ b/aestest.py
@@ -144,6 +144,7 @@ if __name__ == '__main__':
 	for _ in range(args.i):
 		if args.p:
 			if args.c:
+				print("-------running chunksize test--------")
 				time = aesencrypt.AES_Enc_Parallel_chunksize(args, key)
 			elif args.encrypt:
 				time = aesencrypt.AES_Encrypt_Parallelized(args, key)

--- a/aestest.py
+++ b/aestest.py
@@ -14,27 +14,41 @@ import tools
 import sys
 import randfile
 import statistics
+import numpy as np
+import logging
+from datetime import datetime
+
+# Coefficient of Variance
+cv = lambda x: np.std(x, ddof=1) / np.mean(x) * 100
+
+logger: logging = None
 
 TIME_TRIALS = []
+
 def arg_printer(args):
+	logger.info(args)
 	print(args)
 
 
 def arg_checker(args):
 	if args.outf is None:
+		logger.error('[ERROR] Please provide an output file path to continue')
 		print('[ERROR] Please provide an output file path to continue')
 		exit(-101)
 
 	if args.g is not None:
+		logger.info(f'Generating File of size {args.g}\n')
 		print(f'Generating File of size {args.g}\n')
 		f_name = randfile.main_wrapper(int(args.g))
 		args.inf = f_name
 	else:
 		if args.inf:
 			if not os.access(args.inf, os.R_OK):
+				logger.error('[ERROR] Cannot open file for reading')
 				print('[ERROR] Cannot open file for reading')
 				exit(-100)
 		else:
+			logger.error('[ERROR] Cannot open file for reading')
 			print('[ERROR] Please provide an input file path to continue')
 			exit(-101)
 
@@ -48,12 +62,28 @@ def key_check(args):
 	else:
 		# Generate new random 16-byte key upon runtime
 		key = os.urandom(16)
+		logger.info(f'[INFO] Generated and saved key to AES.key:\r')
 		print(f'[INFO] Generated and saved key to AES.key:\r')
 		tools.debug_print_arr_hex_1line(key)
 		with open('AES.key', 'wb') as kf:
 			kf.write(key)
 
 	return key
+
+
+def set_log(a):
+	global logger
+	now = datetime.now()
+	dt_string = now.strftime("%m%d%Y_%H%M%S")
+	logger = logging.getLogger(__name__)
+
+	# Create a log file in eval_files with MMDDYY_HHMMSS_outf.log
+	if "Win" in platform.system():
+		index = a.outf.rfind('/')
+		logging.basicConfig(filename=f'eval_files\\{dt_string}_{a.outf[index+1::]}.log', encoding='utf-8', level=logging.DEBUG)
+	if "Darwin" in platform.system():
+		index = a.outf.rfind('\\')
+		logging.basicConfig(filename=f'eval_files/{dt_string}_{a.outf[index+1::]}.log', encoding='utf-8', level=logging.DEBUG)
 
 
 if __name__ == '__main__':
@@ -82,6 +112,9 @@ if __name__ == '__main__':
 	mode.add_argument('-e', '--encrypt', action='store_true', help='[Mutual Exclusive Required] Encrypt flag')
 
 	args = parser.parse_args()
+
+	# Set logger
+	set_log(args)
 
 	# Sample output
 	arg_printer(args)
@@ -113,10 +146,14 @@ if __name__ == '__main__':
 		# Obtain times from individual runs
 		TIME_TRIALS.append(time)
 
+	Coefficient_of_Variation = cv(TIME_TRIALS)
+
 	print()
-	print("           AES Statistics           ")
-	print("------------------------------------")
-	print(f'Number of Trials: {len(TIME_TRIALS)}')
-	print(f'Average Time: {sum(TIME_TRIALS)/len(TIME_TRIALS)}')
-	print(f'Variance: {statistics.variance(TIME_TRIALS)}')
-	print("------------------------------------")
+	logger.info("           AES Statistics           ")
+	logger.info("------------------------------------")
+	logger.info(f'Number of Trials: {len(TIME_TRIALS)}')
+	logger.info(f'Time Splits: {TIME_TRIALS}')
+	logger.info(f'Average Time: {sum(TIME_TRIALS) / len(TIME_TRIALS)}')
+	logger.info(f'Variance: {statistics.variance(TIME_TRIALS)}')  # NOTE: REQUIRES > 1 ITERATIONS
+	logger.info(f'Coefficient of Variation: {Coefficient_of_Variation}')
+	logger.info("------------------------------------")

--- a/run_results/100KB_Encr.txt
+++ b/run_results/100KB_Encr.txt
@@ -1,0 +1,18 @@
+------------------------------------
+CSCI-555L AES-128 ECB Implementation
+------------------------------------
+[OS]: Darwin
+[Cores]: 8
+Namespace(p=False, k='AES.key', w=-1, i=10, g=102400, inf=None, outf='eval_files/nonParallel/encrypt/100KB.enc', decrypt=False, encrypt=True)
+Generating File of size 102400
+
+Generating random text file of length 102400 bytes
+
+b'414553544553544b45594b45594b4559'
+
+           AES Statistics           
+------------------------------------
+Number of Trials: 10
+Average Time: 4.972962
+Variance: 61.74600395296512
+------------------------------------

--- a/run_results/10KB_Encr.txt
+++ b/run_results/10KB_Encr.txt
@@ -1,0 +1,18 @@
+------------------------------------
+CSCI-555L AES-128 ECB Implementation
+------------------------------------
+[OS]: Darwin
+[Cores]: 8
+Namespace(p=False, k='AES.key', w=-1, i=10, g=10240, inf=None, outf='eval_files/nonParallel/encrypt/10KB.enc', decrypt=False, encrypt=True)
+Generating File of size 10240
+
+Generating random text file of length 10240 bytes
+
+b'414553544553544b45594b45594b4559'
+
+           AES Statistics           
+------------------------------------
+Number of Trials: 10
+Average Time: 0.20812369999999994
+Variance: 1.846642455555554e-06
+------------------------------------

--- a/run_results/16B_Encr.txt
+++ b/run_results/16B_Encr.txt
@@ -1,0 +1,18 @@
+------------------------------------
+CSCI-555L AES-128 ECB Implementation
+------------------------------------
+[OS]: Darwin
+[Cores]: 8
+Namespace(p=False, k='AES.key', w=-1, i=100, g=16, inf=None, outf='eval_files/nonParallel/encrypt/16b.enc', decrypt=False, encrypt=True)
+Generating File of size 16
+
+Generating random text file of length 16 bytes
+
+b'414553544553544b45594b45594b4559'
+
+           AES Statistics           
+------------------------------------
+Number of Trials: 100
+Average Time: 0.00027591000000000003
+Variance: 8.245473737373737e-10
+------------------------------------

--- a/run_results/1KB_Encr.txt
+++ b/run_results/1KB_Encr.txt
@@ -1,0 +1,18 @@
+------------------------------------
+CSCI-555L AES-128 ECB Implementation
+------------------------------------
+[OS]: Darwin
+[Cores]: 8
+Namespace(p=False, k='AES.key', w=-1, i=10, g=1024, inf=None, outf='eval_files/nonParallel/encrypt/1KB.enc', decrypt=False, encrypt=True)
+Generating File of size 1024
+
+Generating random text file of length 1024 bytes
+
+b'414553544553544b45594b45594b4559'
+
+           AES Statistics           
+------------------------------------
+Number of Trials: 10
+Average Time: 0.0175418
+Variance: 2.1151084444444413e-07
+------------------------------------

--- a/run_results/256KB_Encr.txt
+++ b/run_results/256KB_Encr.txt
@@ -1,0 +1,18 @@
+------------------------------------
+CSCI-555L AES-128 ECB Implementation
+------------------------------------
+[OS]: Darwin
+[Cores]: 8
+Namespace(p=False, k='AES.key', w=-1, i=10, g=262144, inf=None, outf='eval_files/nonParallel/encrypt/256KB.enc', decrypt=False, encrypt=True)
+Generating File of size 262144
+
+Generating random text file of length 262144 bytes
+
+b'414553544553544b45594b45594b4559'
+
+           AES Statistics           
+------------------------------------
+Number of Trials: 10
+Average Time: 198.2264668
+Variance: 331748.61319207883
+------------------------------------

--- a/run_results/50KB_Encr.txt
+++ b/run_results/50KB_Encr.txt
@@ -1,0 +1,18 @@
+------------------------------------
+CSCI-555L AES-128 ECB Implementation
+------------------------------------
+[OS]: Darwin
+[Cores]: 8
+Namespace(p=False, k='AES.key', w=-1, i=10, g=51200, inf=None, outf='eval_files/nonParallel/encrypt/50KB.enc', decrypt=False, encrypt=True)
+Generating File of size 51200
+
+Generating random text file of length 51200 bytes
+
+b'414553544553544b45594b45594b4559'
+
+           AES Statistics           
+------------------------------------
+Number of Trials: 10
+Average Time: 1.0470527
+Variance: 0.0003903236982333336
+------------------------------------


### PR DESCRIPTION
## Test Chunksize
Adds support for testing the chunksize argument for the project evaluation. Allows the user to specify the number of blocks given to each process (`worker`) at a time. The blocks are already padded by this point, so it will take any number of blocks as an argument.

# Example usage:
python3 aestest.py -e -p -w 6 -c 13 -inf eval_files/1048576.txt -i 3 -k AES.key -outf eval_files/parallel/encrypt/1MB.enc 

The above command runs  encryption with 6 workers and a chunksize of c=13 blocks per process. Omitting the `-c` flag will have the program run in a normal mode, where the chunksize is an even split between all workers in the process pool.

Support is added for decryption and encryption with the `-c` flag.

